### PR TITLE
feat: switch to use Pragma Cairo 1 contract

### DIFF
--- a/src/interfaces.cairo
+++ b/src/interfaces.cairo
@@ -257,7 +257,7 @@ trait IInterestRateModel<TContractState> {
 
 #[starknet::interface]
 trait IPragmaOracle<TContractState> {
-    fn get_spot_median(self: @TContractState, pair_id: felt252) -> PragmaOracleSpotMedian;
+    fn get_data_median(self: @TContractState, data_type: PragmaDataType) -> PragmaPricesResponse;
 }
 
 #[starknet::interface]
@@ -308,9 +308,17 @@ struct PriceWithUpdateTime {
 }
 
 #[derive(Drop, Serde)]
-struct PragmaOracleSpotMedian {
-    price: felt252,
-    decimals: felt252,
-    last_updated_timestamp: felt252,
-    num_sources_aggregated: felt252
+enum PragmaDataType {
+    SpotEntry: felt252,
+    FutureEntry: (felt252, u64),
+    GenericEntry: felt252,
+}
+
+#[derive(Drop, Serde)]
+struct PragmaPricesResponse {
+    price: u128,
+    decimals: u32,
+    last_updated_timestamp: u64,
+    num_sources_aggregated: u32,
+    expiration_timestamp: Option<u64>,
 }

--- a/tests/mock.cairo
+++ b/tests/mock.cairo
@@ -196,10 +196,10 @@ trait IMockPragmaOracle<TContractState> {
     fn set_price(
         ref self: TContractState,
         pair_id: felt252,
-        price: felt252,
-        decimals: felt252,
-        last_updated_timestamp: felt252,
-        num_sources_aggregated: felt252
+        price: u128,
+        decimals: u32,
+        last_updated_timestamp: u64,
+        num_sources_aggregated: u32
     );
 }
 

--- a/tests/mock/mock_pragma_oracle.cairo
+++ b/tests/mock/mock_pragma_oracle.cairo
@@ -2,27 +2,30 @@
 mod MockPragmaOracle {
     use starknet::ContractAddress;
 
-    use zklend::interfaces::{IPragmaOracle, PragmaOracleSpotMedian};
+    use zklend::interfaces::{IPragmaOracle, PragmaDataType, PragmaPricesResponse};
 
     use super::super::IMockPragmaOracle;
 
     #[storage]
     struct Storage {
         pair_id: felt252,
-        price: felt252,
-        decimals: felt252,
-        last_updated_timestamp: felt252,
-        num_sources_aggregated: felt252
+        price: u128,
+        decimals: u32,
+        last_updated_timestamp: u64,
+        num_sources_aggregated: u32
     }
 
     #[external(v0)]
     impl IPragmaOracleImpl of IPragmaOracle<ContractState> {
-        fn get_spot_median(self: @ContractState, pair_id: felt252) -> PragmaOracleSpotMedian {
-            PragmaOracleSpotMedian {
+        fn get_data_median(
+            self: @ContractState, data_type: PragmaDataType
+        ) -> PragmaPricesResponse {
+            PragmaPricesResponse {
                 price: self.price.read(),
                 decimals: self.decimals.read(),
                 last_updated_timestamp: self.last_updated_timestamp.read(),
-                num_sources_aggregated: self.num_sources_aggregated.read()
+                num_sources_aggregated: self.num_sources_aggregated.read(),
+                expiration_timestamp: Option::None,
             }
         }
     }
@@ -32,10 +35,10 @@ mod MockPragmaOracle {
         fn set_price(
             ref self: ContractState,
             pair_id: felt252,
-            price: felt252,
-            decimals: felt252,
-            last_updated_timestamp: felt252,
-            num_sources_aggregated: felt252
+            price: u128,
+            decimals: u32,
+            last_updated_timestamp: u64,
+            num_sources_aggregated: u32
         ) {
             self.pair_id.write(pair_id);
             self.price.write(price);


### PR DESCRIPTION
The Cairo 1 version contains breaking changes on the public interface. This PR updates the `PragmaOracleAdapter` contract to use the new interface instead.