### PR TITLE
feat: skip price fetching if collateral factor is zero

### DIFF
--- a/src/market/internal.cairo
+++ b/src/market/internal.cairo
@@ -631,6 +631,10 @@ fn get_user_collateral_usd_value_for_token(
 ) -> felt252 {
     let reserve = self.reserves.read_for_get_user_collateral_usd_value_for_token(token);
 
+    if reserve.collateral_factor.is_zero() {
+        return 0;
+    }
+
     // This value already reflects interests accured since last update
     let collateral_balance = IZTokenDispatcher {
         contract_address: reserve.z_token_address

--- a/tests/mock/mock_price_oracle.cairo
+++ b/tests/mock/mock_price_oracle.cairo
@@ -1,6 +1,7 @@
 #[starknet::contract]
 mod MockPriceOracle {
     use starknet::ContractAddress;
+    use zeroable::Zeroable;
 
     use zklend::interfaces::{IPriceOracle, PriceWithUpdateTime};
 
@@ -21,6 +22,7 @@ mod MockPriceOracle {
     impl IPriceOracleImpl of IPriceOracle<ContractState> {
         fn get_price(self: @ContractState, token: ContractAddress) -> felt252 {
             let data = self.prices.read(token);
+            assert(!data.price.is_zero(), 'MOCK_ORACLE_PRICE_NOT_SET');
             data.price
         }
 
@@ -28,6 +30,7 @@ mod MockPriceOracle {
             self: @ContractState, token: ContractAddress
         ) -> PriceWithUpdateTime {
             let data = self.prices.read(token);
+            assert(!data.price.is_zero(), 'MOCK_ORACLE_PRICE_NOT_SET');
             return PriceWithUpdateTime { price: data.price, update_time: data.update_time };
         }
     }


### PR DESCRIPTION
This enables "prelisting" tokens that don't have a price source configured yet.