### PR TITLE
feat: no longer interprete 0 as no debt limit

### DIFF
--- a/src/market/internal.cairo
+++ b/src/market/internal.cairo
@@ -916,18 +916,15 @@ fn assert_reserve_enabled(self: @ContractState, token: ContractAddress) {
 fn assert_debt_limit_satisfied(self: @ContractState, token: ContractAddress) {
     let debt_limit = self.reserves.read_debt_limit(token);
 
-    // 0 means no limit
-    if debt_limit.is_non_zero() {
-        let raw_total_debt = self.reserves.read_raw_total_debt(token);
+    let raw_total_debt = self.reserves.read_raw_total_debt(token);
 
-        let debt_accumulator = view::get_debt_accumulator(self, token);
-        let scaled_debt = safe_decimal_math::mul(raw_total_debt, debt_accumulator);
+    let debt_accumulator = view::get_debt_accumulator(self, token);
+    let scaled_debt = safe_decimal_math::mul(raw_total_debt, debt_accumulator);
 
-        assert(
-            Into::<_, u256>::into(scaled_debt) <= Into::<_, u256>::into(debt_limit),
-            errors::DEBT_LIMIT_EXCEEDED
-        );
-    }
+    assert(
+        Into::<_, u256>::into(scaled_debt) <= Into::<_, u256>::into(debt_limit),
+        errors::DEBT_LIMIT_EXCEEDED
+    );
 }
 
 /// This function is called to distribute excessive reserve assets to depositors. Such extra balance

--- a/tests/market.cairo
+++ b/tests/market.cairo
@@ -130,6 +130,21 @@ fn setup() -> Setup {
         );
 
     setup
+        .alice
+        .market_set_debt_limit(
+            setup.market.contract_address,
+            setup.token_a.contract_address, // token
+            999999999999999999999999999999 // limit
+        );
+    setup
+        .alice
+        .market_set_debt_limit(
+            setup.market.contract_address,
+            setup.token_b.contract_address, // token
+            999999999999999999999999999999 // limit
+        );
+
+    setup
         .oracle
         .set_price(
             setup.token_a.contract_address, // token


### PR DESCRIPTION
It's legitimate to have tokens that cannot be borrowed, and `debt_limit` is a good way to handle that. All tokens in production have a non-zero `debt_limit` so this upgrade does not break anything.