### PR TITLE
feat: interest rate model setter

### DIFF
--- a/src/interfaces.cairo
+++ b/src/interfaces.cairo
@@ -110,6 +110,10 @@ trait IMarket<TContractState> {
 
     fn set_treasury(ref self: TContractState, new_treasury: ContractAddress);
 
+    fn set_interest_rate_model(
+        ref self: TContractState, token: ContractAddress, interest_rate_model: ContractAddress
+    );
+
     fn set_collateral_factor(
         ref self: TContractState, token: ContractAddress, collateral_factor: felt252
     );

--- a/src/market.cairo
+++ b/src/market.cairo
@@ -47,6 +47,7 @@ mod Market {
         TreasuryUpdate: TreasuryUpdate,
         AccumulatorsSync: AccumulatorsSync,
         InterestRatesSync: InterestRatesSync,
+        InterestRateModelUpdate: InterestRateModelUpdate,
         CollateralFactorUpdate: CollateralFactorUpdate,
         BorrowFactorUpdate: BorrowFactorUpdate,
         DebtLimitUpdate: DebtLimitUpdate,
@@ -92,6 +93,12 @@ mod Market {
         token: ContractAddress,
         lending_rate: felt252,
         borrowing_rate: felt252
+    }
+
+    #[derive(Drop, PartialEq, starknet::Event)]
+    struct InterestRateModelUpdate {
+        token: ContractAddress,
+        interest_rate_model: ContractAddress
     }
 
     #[derive(Drop, PartialEq, starknet::Event)]
@@ -335,6 +342,12 @@ mod Market {
 
         fn set_treasury(ref self: ContractState, new_treasury: ContractAddress) {
             external::set_treasury(ref self, new_treasury)
+        }
+
+        fn set_interest_rate_model(
+            ref self: ContractState, token: ContractAddress, interest_rate_model: ContractAddress
+        ) {
+            external::set_interest_rate_model(ref self, token, interest_rate_model)
         }
 
         fn set_collateral_factor(

--- a/src/market/storage.cairo
+++ b/src/market/storage.cairo
@@ -102,6 +102,10 @@ trait ReservesStorageShortcuts<T> {
 
     fn write_raw_total_debt(self: @T, token: ContractAddress, raw_total_debt: felt252);
 
+    fn write_interest_rate_model(
+        self: @T, token: ContractAddress, interest_rate_model: ContractAddress
+    );
+
     fn write_collateral_factor(self: @T, token: ContractAddress, collateral_factor: felt252);
 
     fn write_borrow_factor(self: @T, token: ContractAddress, borrow_factor: felt252);
@@ -276,6 +280,15 @@ impl ReservesStorageShortcutsImpl of ReservesStorageShortcuts<Reserves> {
 
         Store::<felt252>::write_at_offset(D, base, 12, raw_total_debt).expect(E);
     }
+
+    fn write_interest_rate_model(
+        self: @Reserves, token: ContractAddress, interest_rate_model: ContractAddress
+    ) {
+        let base = self.address(token);
+
+        Store::<ContractAddress>::write_at_offset(D, base, 3, interest_rate_model).expect(E);
+    }
+
 
     fn write_collateral_factor(
         self: @Reserves, token: ContractAddress, collateral_factor: felt252

--- a/tests/mock.cairo
+++ b/tests/mock.cairo
@@ -67,6 +67,13 @@ trait IAccount<TContractState> {
         ref self: TContractState, contract_address: ContractAddress, new_treasury: ContractAddress
     );
 
+    fn market_set_interest_rate_model(
+        ref self: TContractState,
+        contract_address: ContractAddress,
+        token: ContractAddress,
+        interest_rate_model: ContractAddress
+    );
+
     fn market_set_collateral_factor(
         ref self: TContractState,
         contract_address: ContractAddress,

--- a/tests/mock/account.cairo
+++ b/tests/mock/account.cairo
@@ -56,6 +56,17 @@ mod Account {
             IMarketDispatcher { contract_address }.set_treasury(new_treasury)
         }
 
+        fn market_set_interest_rate_model(
+            ref self: ContractState,
+            contract_address: ContractAddress,
+            token: ContractAddress,
+            interest_rate_model: ContractAddress
+        ) {
+            IMarketDispatcher {
+                contract_address
+            }.set_interest_rate_model(token, interest_rate_model)
+        }
+
         fn market_set_collateral_factor(
             ref self: ContractState,
             contract_address: ContractAddress,


### PR DESCRIPTION
Upon setting a new interest rate model, pending interests are settled immediately using the old rates.