### PR TITLE
feat: support chainlink via dual oracle setup

### DIFF
--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -26,6 +26,8 @@ compile zklend::market Market
 compile zklend::z_token ZToken
 compile zklend::default_price_oracle DefaultPriceOracle
 compile zklend::irms::default_interest_rate_model DefaultInterestRateModel
+compile zklend::oracles::dual_oracle_adapter DualOracleAdapter
+compile zklend::oracles::chainlink_oracle_adapter ChainlinkOracleAdapter
 compile zklend::oracles::pragma_oracle_adapter PragmaOracleAdapter
 
 if [ -n "$USER_ID" ] && [ -n "$GROUP_ID" ]; then

--- a/src/interfaces.cairo
+++ b/src/interfaces.cairo
@@ -287,6 +287,13 @@ trait IPragmaOracle<TContractState> {
 }
 
 #[starknet::interface]
+trait IChainlinkOracle<TContractState> {
+    fn latest_round_data(self: @TContractState) -> ChainlinkPricesResponse;
+
+    fn decimals(self: @TContractState) -> u8;
+}
+
+#[starknet::interface]
 trait IERC20<TContractState> {
     fn decimals(self: @TContractState) -> felt252;
 
@@ -348,4 +355,19 @@ struct PragmaPricesResponse {
     last_updated_timestamp: u64,
     num_sources_aggregated: u32,
     expiration_timestamp: Option<u64>,
+}
+
+#[derive(Drop, Serde)]
+struct ChainlinkPricesResponse {
+    /// The unique identifier of the data round.
+    round_id: felt252,
+    /// The actual data provided by the data feed, representing the latest price of an asset in the
+    /// case of a price feed.
+    answer: u128,
+    /// The block number at which the data was recorded on the blockchain.
+    block_num: u64,
+    /// The Unix timestamp indicating when the data round started.
+    started_at: u64,
+    /// The Unix timestamp indicating when the data was last updated.
+    updated_at: u64,
 }

--- a/src/oracles.cairo
+++ b/src/oracles.cairo
@@ -1,1 +1,5 @@
+mod dual_oracle_adapter;
+
 mod pragma_oracle_adapter;
+
+mod chainlink_oracle_adapter;

--- a/src/oracles/chainlink_oracle_adapter.cairo
+++ b/src/oracles/chainlink_oracle_adapter.cairo
@@ -1,0 +1,93 @@
+mod errors {
+    const STALED_PRICE: felt252 = 'CHAINLINK_STALED_PRICE';
+    const ZERO_PRICE: felt252 = 'CHAINLINK_ZERO_PRICE';
+}
+
+#[starknet::contract]
+mod ChainlinkOracleAdapter {
+    use integer::u64_checked_sub;
+    use option::OptionTrait;
+    use traits::{Into, TryInto};
+
+    use starknet::{ContractAddress, get_block_timestamp};
+
+    // Hack to simulate the `crate` keyword
+    use super::super::super as crate;
+
+    use crate::interfaces::{
+        IChainlinkOracleDispatcher, IChainlinkOracleDispatcherTrait, IPriceOracleSource,
+        ChainlinkPricesResponse, PriceWithUpdateTime
+    };
+    use crate::libraries::{pow, safe_math};
+
+    use super::errors;
+
+    // These two consts MUST be the same.
+    const TARGET_DECIMALS: felt252 = 8;
+    const TARGET_DECIMALS_U256: u256 = 8;
+
+    #[storage]
+    struct Storage {
+        oracle: ContractAddress,
+        pair: felt252,
+        timeout: u64
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, oracle: ContractAddress, timeout: u64) {
+        self.oracle.write(oracle);
+        self.timeout.write(timeout);
+    }
+
+    #[abi(embed_v0)]
+    impl IPriceOracleSourceImpl of IPriceOracleSource<ContractState> {
+        fn get_price(self: @ContractState) -> felt252 {
+            get_data(self).price
+        }
+
+        fn get_price_with_time(self: @ContractState) -> PriceWithUpdateTime {
+            get_data(self)
+        }
+    }
+
+    fn get_data(self: @ContractState) -> PriceWithUpdateTime {
+        let oracle_addr = self.oracle.read();
+
+        let round_data = IChainlinkOracleDispatcher { contract_address: oracle_addr }
+            .latest_round_data();
+        assert(round_data.answer != 0, errors::ZERO_PRICE);
+
+        // Block times are usually behind real world time by a bit. It's possible that the reported
+        // last updated timestamp is in the (very near) future.
+        let block_time: u64 = get_block_timestamp();
+
+        let time_elasped: u64 = match u64_checked_sub(block_time, round_data.updated_at) {
+            Option::Some(value) => value,
+            Option::None => 0,
+        };
+        let timeout = self.timeout.read();
+        assert(time_elasped <= timeout, errors::STALED_PRICE);
+
+        let decimals = IChainlinkOracleDispatcher { contract_address: oracle_addr }.decimals();
+
+        let scaled_price = scale_price(round_data.answer.into(), decimals.into());
+        PriceWithUpdateTime { price: scaled_price, update_time: round_data.updated_at.into() }
+    }
+
+    fn scale_price(price: felt252, decimals: felt252) -> felt252 {
+        if decimals == TARGET_DECIMALS {
+            price
+        } else {
+            let should_scale_up = Into::<_, u256>::into(decimals) < TARGET_DECIMALS_U256;
+            if should_scale_up {
+                let multiplier = pow::ten_pow(TARGET_DECIMALS - decimals);
+                let scaled_price = safe_math::mul(price, multiplier);
+                scaled_price
+            } else {
+                let multiplier = pow::ten_pow(decimals - TARGET_DECIMALS);
+                let scaled_price = safe_math::div(price, multiplier);
+                scaled_price
+            }
+        }
+    }
+}

--- a/src/oracles/dual_oracle_adapter.cairo
+++ b/src/oracles/dual_oracle_adapter.cairo
@@ -1,0 +1,91 @@
+mod errors {
+    const DIVERGING_UPSTREAMS: felt252 = 'DUAL_DIVERGING_UPSTREAMS';
+}
+
+/// An oracle implementation that implements `IPriceOracleSource` but is backed by two upstream
+/// `IPriceOracleSource` oracles. The final output is the average price of the upstreams as long as
+/// they don't diverge beyond a configured threshold; otherwise an error is thrown.
+#[starknet::contract]
+mod DualOracleAdapter {
+    use starknet::ContractAddress;
+
+    // Hack to simulate the `crate` keyword
+    use super::super::super as crate;
+
+    use crate::interfaces::{
+        IPriceOracleSource, IPriceOracleSourceDispatcher, IPriceOracleSourceDispatcherTrait,
+        PriceWithUpdateTime
+    };
+    use crate::libraries::safe_decimal_math;
+
+    use super::errors;
+
+    #[storage]
+    struct Storage {
+        upstream_0: ContractAddress,
+        upstream_1: ContractAddress,
+        threshold: felt252,
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        upstream_0: ContractAddress,
+        upstream_1: ContractAddress,
+        threshold: felt252
+    ) {
+        self.upstream_0.write(upstream_0);
+        self.upstream_1.write(upstream_1);
+        self.threshold.write(threshold);
+    }
+
+    #[abi(embed_v0)]
+    impl IPriceOracleSourceImpl of IPriceOracleSource<ContractState> {
+        fn get_price(self: @ContractState) -> felt252 {
+            get_data(self).price
+        }
+
+        fn get_price_with_time(self: @ContractState) -> PriceWithUpdateTime {
+            get_data(self)
+        }
+    }
+
+    fn get_data(self: @ContractState) -> PriceWithUpdateTime {
+        // There is no need to scale the prices as all `IPriceOracleSource` implementations are
+        // guaranteed to return at target decimals.
+        let price_0 = IPriceOracleSourceDispatcher { contract_address: self.upstream_0.read() }
+            .get_price_with_time();
+        let price_1 = IPriceOracleSourceDispatcher { contract_address: self.upstream_1.read() }
+            .get_price_with_time();
+
+        let price_0_u256: u256 = price_0.price.into();
+        let price_1_u256: u256 = price_1.price.into();
+
+        let (lower_felt, lower, upper) = if price_0_u256 < price_1_u256 {
+            (price_0.price, price_0_u256, price_1_u256)
+        } else {
+            (price_1.price, price_1_u256, price_0_u256)
+        };
+
+        assert(
+            lower
+                + Into::<
+                    _, u256
+                >::into(safe_decimal_math::mul(lower_felt, self.threshold.read())) >= upper,
+            errors::DIVERGING_UPSTREAMS
+        );
+
+        PriceWithUpdateTime {
+            price: ((price_0_u256 + price_1_u256) / 2).try_into().unwrap(),
+            update_time: if Into::<
+                _, u256
+                >::into(price_0.update_time) < Into::<
+                _, u256
+            >::into(price_1.update_time) {
+                price_0.update_time
+            } else {
+                price_1.update_time
+            },
+        }
+    }
+}

--- a/tests/chainlink_oracle_adapter.cairo
+++ b/tests/chainlink_oracle_adapter.cairo
@@ -1,0 +1,42 @@
+use test::test_utils::assert_eq;
+
+use zklend::interfaces::IPriceOracleSourceDispatcherTrait;
+
+use tests::deploy;
+use tests::mock::IMockChainlinkOracleDispatcherTrait;
+
+#[test]
+#[available_gas(30000000)]
+fn test_not_staled_price() {
+    let mock_chainlink_oracle = deploy::deploy_mock_chainlink_oracle();
+    let chainlink_oracle_adpater = deploy::deploy_chainlink_oracle_adapter(
+        mock_chainlink_oracle.contract_address, 500
+    );
+
+    // Set last update timestamp to 100
+    mock_chainlink_oracle.set_price(5, 10000_00000000, 1, 0, 100);
+
+    // Current block time is 0. It's okay for the updated time to be in the future.
+    chainlink_oracle_adpater.get_price();
+
+    // It's still acceptable when the time elasped equals timeout.
+    starknet::testing::set_block_timestamp(600);
+    chainlink_oracle_adpater.get_price();
+}
+
+#[test]
+#[available_gas(30000000)]
+#[should_panic(expected: ('CHAINLINK_STALED_PRICE', 'ENTRYPOINT_FAILED'))]
+fn test_staled_price() {
+    let mock_chainlink_oracle = deploy::deploy_mock_chainlink_oracle();
+    let chainlink_oracle_adpater = deploy::deploy_chainlink_oracle_adapter(
+        mock_chainlink_oracle.contract_address, 500
+    );
+
+    // Set last update timestamp to 100
+    mock_chainlink_oracle.set_price(5, 10000_00000000, 1, 0, 100);
+
+    // One second over timeout will be rejected.
+    starknet::testing::set_block_timestamp(601);
+    chainlink_oracle_adpater.get_price();
+}

--- a/tests/deploy.cairo
+++ b/tests/deploy.cairo
@@ -12,13 +12,16 @@ use zklend::interfaces::{
 };
 use zklend::irms::default_interest_rate_model::DefaultInterestRateModel;
 use zklend::market::Market;
+use zklend::oracles::chainlink_oracle_adapter::ChainlinkOracleAdapter;
+use zklend::oracles::dual_oracle_adapter::DualOracleAdapter;
 use zklend::oracles::pragma_oracle_adapter::PragmaOracleAdapter;
 use zklend::z_token::ZToken;
 
 use tests::mock;
 use tests::mock::{
-    IAccountDispatcher, IERC20Dispatcher, IFlashLoanHandlerDispatcher, IMockMarketDispatcher,
-    IMockPragmaOracleDispatcher, IMockPriceOracleDispatcher
+    IAccountDispatcher, IERC20Dispatcher, IFlashLoanHandlerDispatcher,
+    IMockChainlinkOracleDispatcher, IMockMarketDispatcher, IMockPragmaOracleDispatcher,
+    IMockPriceOracleDispatcher
 };
 
 fn deploy_account(salt: felt252) -> IAccountDispatcher {
@@ -67,6 +70,18 @@ fn deploy_mock_price_oracle() -> IMockPriceOracleDispatcher {
     IMockPriceOracleDispatcher { contract_address }
 }
 
+fn deploy_mock_chainlink_oracle() -> IMockChainlinkOracleDispatcher {
+    let (contract_address, _) = deploy_syscall(
+        mock::mock_chainlink_oracle::MockChainlinkOracle::TEST_CLASS_HASH.try_into().unwrap(),
+        0,
+        Default::default().span(),
+        false
+    )
+        .unwrap();
+
+    IMockChainlinkOracleDispatcher { contract_address }
+}
+
 fn deploy_mock_pragma_oracle() -> IMockPragmaOracleDispatcher {
     let (contract_address, _) = deploy_syscall(
         mock::mock_pragma_oracle::MockPragmaOracle::TEST_CLASS_HASH.try_into().unwrap(),
@@ -101,6 +116,34 @@ fn deploy_flash_loan_handler() -> IFlashLoanHandlerDispatcher {
         .unwrap();
 
     IFlashLoanHandlerDispatcher { contract_address }
+}
+
+fn deploy_dual_oracle_adapter(
+    upstream_0: ContractAddress, upstream_1: ContractAddress, threshold: felt252
+) -> IPriceOracleSourceDispatcher {
+    let (contract_address, _) = deploy_syscall(
+        DualOracleAdapter::TEST_CLASS_HASH.try_into().unwrap(),
+        0,
+        array![upstream_0.into(), upstream_1.into(), threshold].span(),
+        false
+    )
+        .unwrap();
+
+    IPriceOracleSourceDispatcher { contract_address }
+}
+
+fn deploy_chainlink_oracle_adapter(
+    oracle: ContractAddress, timeout: felt252
+) -> IPriceOracleSourceDispatcher {
+    let (contract_address, _) = deploy_syscall(
+        ChainlinkOracleAdapter::TEST_CLASS_HASH.try_into().unwrap(),
+        0,
+        array![oracle.into(), timeout].span(),
+        false
+    )
+        .unwrap();
+
+    IPriceOracleSourceDispatcher { contract_address }
 }
 
 fn deploy_pragma_oracle_adapter(

--- a/tests/dual_oracle_adapter.cairo
+++ b/tests/dual_oracle_adapter.cairo
@@ -1,0 +1,106 @@
+use test::test_utils::assert_eq;
+
+use zklend::interfaces::IPriceOracleSourceDispatcherTrait;
+
+use tests::deploy;
+use tests::mock::{IMockChainlinkOracleDispatcherTrait, IMockPragmaOracleDispatcherTrait};
+
+#[test]
+#[available_gas(30000000)]
+fn test_average_price() {
+    let mock_chainlink_oracle = deploy::deploy_mock_chainlink_oracle();
+    let mock_pragma_oracle = deploy::deploy_mock_pragma_oracle();
+
+    let chainlink_oracle_adpater = deploy::deploy_chainlink_oracle_adapter(
+        mock_chainlink_oracle.contract_address, 500
+    );
+    let pragma_oracle_adpater = deploy::deploy_pragma_oracle_adapter(
+        mock_pragma_oracle.contract_address, 'BTC/USD', 500
+    );
+
+    // 10% threshold
+    let dual_oracle_adapter = deploy::deploy_dual_oracle_adapter(
+        chainlink_oracle_adpater.contract_address,
+        pragma_oracle_adpater.contract_address,
+        0_100000000000000000000000000
+    );
+
+    // Chainlink: 10000; Pragma: 10100
+    mock_chainlink_oracle.set_price(5, 10000_00000000, 1, 0, 100);
+    mock_pragma_oracle.set_price('BTC/USD', 10100_00000000, 8, 100, 5);
+    assert(dual_oracle_adapter.get_price() == 10050_00000000, 'FAILED');
+
+    // Chainlink: 10100; Pragma: 10000
+    mock_chainlink_oracle.set_price(5, 10100_00000000, 1, 0, 100);
+    mock_pragma_oracle.set_price('BTC/USD', 10000_00000000, 8, 100, 5);
+    assert(dual_oracle_adapter.get_price() == 10050_00000000, 'FAILED');
+
+    // Same price
+    mock_chainlink_oracle.set_price(5, 10400_00000000, 1, 0, 100);
+    mock_pragma_oracle.set_price('BTC/USD', 10400_00000000, 8, 100, 5);
+    assert(dual_oracle_adapter.get_price() == 10400_00000000, 'FAILED');
+
+    // Exactly on threshold
+    mock_chainlink_oracle.set_price(5, 10000_00000000, 1, 0, 100);
+    mock_pragma_oracle.set_price('BTC/USD', 11000_00000000, 8, 100, 5);
+    assert(dual_oracle_adapter.get_price() == 10500_00000000, 'FAILED');
+
+    // The other way around
+    mock_chainlink_oracle.set_price(5, 11000_00000000, 1, 0, 100);
+    mock_pragma_oracle.set_price('BTC/USD', 10000_00000000, 8, 100, 5);
+    assert(dual_oracle_adapter.get_price() == 10500_00000000, 'FAILED');
+}
+
+#[test]
+#[available_gas(30000000)]
+#[should_panic(expected: ('DUAL_DIVERGING_UPSTREAMS', 'ENTRYPOINT_FAILED'))]
+fn test_diverged_upstreams_with_0_lower() {
+    let mock_chainlink_oracle = deploy::deploy_mock_chainlink_oracle();
+    let mock_pragma_oracle = deploy::deploy_mock_pragma_oracle();
+
+    let chainlink_oracle_adpater = deploy::deploy_chainlink_oracle_adapter(
+        mock_chainlink_oracle.contract_address, 500
+    );
+    let pragma_oracle_adpater = deploy::deploy_pragma_oracle_adapter(
+        mock_pragma_oracle.contract_address, 'BTC/USD', 500
+    );
+
+    // 10% threshold
+    let dual_oracle_adapter = deploy::deploy_dual_oracle_adapter(
+        chainlink_oracle_adpater.contract_address,
+        pragma_oracle_adpater.contract_address,
+        0_100000000000000000000000000
+    );
+
+    // Chainlink: 10000; Pragma: 11000.00000001
+    mock_chainlink_oracle.set_price(5, 10000_00000000, 1, 0, 100);
+    mock_pragma_oracle.set_price('BTC/USD', 11000_00000001, 8, 100, 5);
+    dual_oracle_adapter.get_price();
+}
+
+#[test]
+#[available_gas(30000000)]
+#[should_panic(expected: ('DUAL_DIVERGING_UPSTREAMS', 'ENTRYPOINT_FAILED'))]
+fn test_diverged_upstreams_with_1_lower() {
+    let mock_chainlink_oracle = deploy::deploy_mock_chainlink_oracle();
+    let mock_pragma_oracle = deploy::deploy_mock_pragma_oracle();
+
+    let chainlink_oracle_adpater = deploy::deploy_chainlink_oracle_adapter(
+        mock_chainlink_oracle.contract_address, 500
+    );
+    let pragma_oracle_adpater = deploy::deploy_pragma_oracle_adapter(
+        mock_pragma_oracle.contract_address, 'BTC/USD', 500
+    );
+
+    // 10% threshold
+    let dual_oracle_adapter = deploy::deploy_dual_oracle_adapter(
+        chainlink_oracle_adpater.contract_address,
+        pragma_oracle_adpater.contract_address,
+        0_100000000000000000000000000
+    );
+
+    // Chainlink: 11000.00000001; Pragma: 10000
+    mock_chainlink_oracle.set_price(5, 11000_00000001, 1, 0, 100);
+    mock_pragma_oracle.set_price('BTC/USD', 10000_00000000, 8, 100, 5);
+    dual_oracle_adapter.get_price();
+}

--- a/tests/lib.cairo
+++ b/tests/lib.cairo
@@ -2,6 +2,12 @@
 mod default_interest_rate_model;
 
 #[cfg(test)]
+mod dual_oracle_adapter;
+
+#[cfg(test)]
+mod chainlink_oracle_adapter;
+
+#[cfg(test)]
 mod pragma_oracle_adapter;
 
 #[cfg(test)]

--- a/tests/mock.cairo
+++ b/tests/mock.cairo
@@ -6,6 +6,8 @@ mod mock_market;
 
 mod mock_price_oracle;
 
+mod mock_chainlink_oracle;
+
 mod mock_pragma_oracle;
 
 mod flash_loan_handler;
@@ -219,6 +221,22 @@ trait IMockPriceOracle<TContractState> {
 
     fn set_price(
         ref self: TContractState, token: ContractAddress, price: felt252, update_time: felt252
+    );
+}
+
+#[starknet::interface]
+trait IMockChainlinkOracle<TContractState> {
+    //
+    // External
+    //
+
+    fn set_price(
+        ref self: TContractState,
+        round_id: felt252,
+        answer: u128,
+        block_num: u64,
+        started_at: u64,
+        updated_at: u64
     );
 }
 

--- a/tests/mock/mock_chainlink_oracle.cairo
+++ b/tests/mock/mock_chainlink_oracle.cairo
@@ -1,0 +1,52 @@
+#[starknet::contract]
+mod MockChainlinkOracle {
+    use starknet::ContractAddress;
+
+    use zklend::interfaces::{IChainlinkOracle, ChainlinkPricesResponse};
+
+    use super::super::IMockChainlinkOracle;
+
+    #[storage]
+    struct Storage {
+        round_id: felt252,
+        answer: u128,
+        block_num: u64,
+        started_at: u64,
+        updated_at: u64,
+    }
+
+    #[abi(embed_v0)]
+    impl IChainlinkOracleImpl of IChainlinkOracle<ContractState> {
+        fn latest_round_data(self: @ContractState) -> ChainlinkPricesResponse {
+            ChainlinkPricesResponse {
+                round_id: self.round_id.read(),
+                answer: self.answer.read(),
+                block_num: self.block_num.read(),
+                started_at: self.started_at.read(),
+                updated_at: self.updated_at.read(),
+            }
+        }
+
+        fn decimals(self: @ContractState) -> u8 {
+            8
+        }
+    }
+
+    #[abi(embed_v0)]
+    impl IMockChainlinkOracleImpl of IMockChainlinkOracle<ContractState> {
+        fn set_price(
+            ref self: ContractState,
+            round_id: felt252,
+            answer: u128,
+            block_num: u64,
+            started_at: u64,
+            updated_at: u64
+        ) {
+            self.round_id.write(round_id);
+            self.answer.write(answer);
+            self.block_num.write(block_num);
+            self.started_at.write(started_at);
+            self.updated_at.write(updated_at);
+        }
+    }
+}


### PR DESCRIPTION
Add support for [Chainlink oracle](https://docs.chain.link/data-feeds/starknet). It will work alongside the current Pragma oracle via a new `DualOracleAdapter` contract. No changes need to be made to the oracle hub contract `DefaultPriceOracle`.